### PR TITLE
[DB수정] rental 엔티티 수정

### DIFF
--- a/src/main/java/com/rental/haedal/admin/dto/res/AdminItemDetailResponse.java
+++ b/src/main/java/com/rental/haedal/admin/dto/res/AdminItemDetailResponse.java
@@ -2,14 +2,15 @@ package com.rental.haedal.admin.dto.res;
 
 import com.rental.haedal.rental.domain.ItemCategory;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public record AdminItemDetailResponse(
         String rentalMemberName,
         String rentalMemberPhoneNumber,
         String itemName,
         ItemCategory itemCategory,
-        Date rentalDate,
+        LocalDate rentalDate,
+        LocalDate returnDate,
         String picture
 ) {
 }

--- a/src/main/java/com/rental/haedal/admin/dto/res/AdminItemListResponse.java
+++ b/src/main/java/com/rental/haedal/admin/dto/res/AdminItemListResponse.java
@@ -3,13 +3,13 @@ package com.rental.haedal.admin.dto.res;
 import com.rental.haedal.rental.domain.ItemCategory;
 import com.rental.haedal.rental.domain.ItemStatus;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public record AdminItemListResponse(
         ItemCategory itemCategory,
         String itemName,
         ItemStatus itemStatus,
-        Date rentalDate,
+        LocalDate returnDate,
         String rentalMemberName
 ) {
 }

--- a/src/main/java/com/rental/haedal/rental/domain/Rental.java
+++ b/src/main/java/com/rental/haedal/rental/domain/Rental.java
@@ -3,11 +3,12 @@ package com.rental.haedal.rental.domain;
 import com.rental.haedal.auth.domain.Member;
 import jakarta.persistence.*;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Entity
 public class Rental {
-    @Id @Column(name = "id")
+    @Id
+    @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -18,8 +19,10 @@ public class Rental {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "itemId")
     private Item item;
+    
+    @Column(name = "rentalDate")
+    private LocalDate rentalDate;
 
-    // JSON에서 직렬화 필요
-    @Column(name = "rentalDuration")
-    private Date rentalDuration;
+    @Column(name = "returnDate")
+    private LocalDate returnDate;
 }

--- a/src/main/java/com/rental/haedal/rental/dto/req/RentalRequest.java
+++ b/src/main/java/com/rental/haedal/rental/dto/req/RentalRequest.java
@@ -2,15 +2,14 @@ package com.rental.haedal.rental.dto.req;
 
 import com.rental.haedal.rental.domain.ItemCategory;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 public record RentalRequest(
         String name,
         ItemCategory itemCategory,
-        Date rentalDate,
+        LocalDate rentalDate,
+        LocalDate returnDate,
         String picture
-
-        // 날짜 포매팅 수정해야함.
         // 대여 물품 사진을 찍어야함.
 ) {
 }


### PR DESCRIPTION
## 📝 상세 내용
- rental 엔티티 대여 날짜, 반납 날짜 함께 구분하도록 하였습니다.
- 엔티티 수정에 따라 수정이 필요한 AdminItemResponse, AdminItemListResponse, RentalRequest DTO 모두 수정하였습니다.
- 수정 내용은 Date -> LocalDate로 수정하였으며 FE에서 대여 날짜, 반납 날짜를 "YYYY-MM-DD" 포맷으로 요청하면 해당하는 데이터를 LocalDate에 담도록 DTO를 수정했습니다.

## #️⃣ 이슈 번호

- #6 

## 💬 리뷰 요구사항
- 요구사항에 맞춰 수정하였는지 확인 부탁드립니다.

## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)
https://dev-coco.tistory.com/117

