### PR TITLE
[기능 수정] 유저의 빌린 물품 API 수정

### DIFF
--- a/src/main/java/com/rental/haedal/dto/rental/res/ItemIndividualResponse.java
+++ b/src/main/java/com/rental/haedal/dto/rental/res/ItemIndividualResponse.java
@@ -1,0 +1,13 @@
+package com.rental.haedal.dto.rental.res;
+
+import com.rental.haedal.domain.enums.ItemCategory;
+
+import java.time.LocalDate;
+
+public record ItemIndividualResponse(
+        long itemId,
+        ItemCategory itemCategory,
+        String itemName,
+        LocalDate dueDate
+) {
+}

--- a/src/main/java/com/rental/haedal/dto/rental/res/ItemIndividualResponse.java
+++ b/src/main/java/com/rental/haedal/dto/rental/res/ItemIndividualResponse.java
@@ -1,6 +1,7 @@
 package com.rental.haedal.dto.rental.res;
 
 import com.rental.haedal.domain.enums.ItemCategory;
+import com.rental.haedal.domain.enums.ItemStatus;
 
 import java.time.LocalDate;
 
@@ -8,6 +9,7 @@ public record ItemIndividualResponse(
         long itemId,
         ItemCategory itemCategory,
         String itemName,
-        LocalDate dueDate
+        LocalDate dueDate,
+        ItemStatus itemStatus
 ) {
 }

--- a/src/main/java/com/rental/haedal/dto/rental/res/UserRentalResponse.java
+++ b/src/main/java/com/rental/haedal/dto/rental/res/UserRentalResponse.java
@@ -3,7 +3,7 @@ package com.rental.haedal.dto.rental.res;
 import java.util.List;
 
 public record UserRentalResponse(
-        List<ItemResponse> userRentalItemList,
+        List<ItemIndividualResponse> userRentalItemList,
         Integer penaltyCount
 ) {
 }

--- a/src/main/java/com/rental/haedal/dto/rental/res/UserRentalResponse.java
+++ b/src/main/java/com/rental/haedal/dto/rental/res/UserRentalResponse.java
@@ -3,7 +3,7 @@ package com.rental.haedal.dto.rental.res;
 import java.util.List;
 
 public record UserRentalResponse(
-        Integer penaltyCount,
-        List<ItemResponse> userRentalItemList
+        List<ItemResponse> userRentalItemList,
+        Integer penaltyCount
 ) {
 }

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -12,10 +12,7 @@ import com.rental.haedal.dto.admin.req.AdminItemRequest;
 import com.rental.haedal.dto.admin.res.AdminItemStatusChangeResponse;
 import com.rental.haedal.dto.rental.req.ItemReturnRequest;
 import com.rental.haedal.dto.rental.req.RentalRequest;
-import com.rental.haedal.dto.rental.res.ItemRentalResponse;
-import com.rental.haedal.dto.rental.res.ItemResponse;
-import com.rental.haedal.dto.rental.res.ItemReturnResponse;
-import com.rental.haedal.dto.rental.res.UserRentalResponse;
+import com.rental.haedal.dto.rental.res.*;
 import com.rental.haedal.repository.ItemRentalRepository;
 import com.rental.haedal.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -77,17 +74,16 @@ public class ItemService {
 
         Integer penaltyCount = member.getPenaltyCount();
 
-        List<ItemResponse> itemResponses = itemRentalRepository.findByMember(member)
+        List<ItemIndividualResponse> itemResponses = itemRentalRepository.findByMember(member)
                 .stream()
-                .map(rental -> new ItemResponse(
+                .map(rental -> new ItemIndividualResponse(
                         rental.getItem().getId(),
-                        rental.getItem().getItemName(),
                         rental.getItem().getCategory(),
-                        rental.getItem().getStatus()))
+                        rental.getItem().getItemName(),
+                        rental.getDueDate()))
                 .toList();
 
         return new UserRentalResponse(itemResponses, penaltyCount);
-
     }
 
     @Transactional

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -86,7 +86,7 @@ public class ItemService {
                         rental.getItem().getStatus()))
                 .toList();
 
-        return new UserRentalResponse(penaltyCount, itemResponses);
+        return new UserRentalResponse(itemResponses, penaltyCount);
 
     }
 

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -80,7 +80,8 @@ public class ItemService {
                         rental.getItem().getId(),
                         rental.getItem().getCategory(),
                         rental.getItem().getItemName(),
-                        rental.getDueDate()))
+                        rental.getDueDate(),
+                        rental.getItem().getStatus()))
                 .sorted(Comparator.comparing(ItemIndividualResponse::dueDate))
                 .toList();
 

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -81,6 +81,7 @@ public class ItemService {
                         rental.getItem().getCategory(),
                         rental.getItem().getItemName(),
                         rental.getDueDate()))
+                .sorted(Comparator.comparing(ItemIndividualResponse::dueDate))
                 .toList();
 
         return new UserRentalResponse(itemResponses, penaltyCount);


### PR DESCRIPTION
## 📝 상세 내용
- 리턴 값에 {[{id, 종류, 이름, 반납 기한}], 제재 횟수} 넘겨주도록 수정
- 또한, 리턴 값이 반납 기한 기준으로 정렬되는 기능 추가
- --
- 첫 번째 사진 요구 사항
- 두 번째 사진 DB상에 무작위로 넣은 값
- 세 번째 사진 API 호출시 반납 기한 기준 오름차순으로 정렬되어 반환되는 것 확인 가능.

## #️⃣ 이슈 번호

- #47 

## 💬 리뷰 요구사항


## ⏰ 현재 버그

## 📷 스크린샷(선택)
![image](https://github.com/user-attachments/assets/e419b895-c257-442d-b79a-3e4d1a019344)

![스크린샷 2025-04-03 020143](https://github.com/user-attachments/assets/b8b3a756-50a9-41b9-a7e8-e0337ba971c0)

![스크린샷 2025-04-03 020201](https://github.com/user-attachments/assets/0d99a2af-362b-40a7-952e-0bc454be2ab8)



## 🔗 참고 자료(선택)

