### PR TITLE
fix: 아이템 대여 시 itemId 대신 rentalId가 반환되던 문제 수정

### DIFF
--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -168,7 +168,7 @@ public class ItemService {
 
         changeItemStatus(item.getId(), ItemStatus.RENTING);
 
-        return new ItemRentalResponse(rental.getId());
+        return new ItemRentalResponse(item.getId());
     }
 
     public AdminItemStatusChangeResponse changeItemStatus(AdminItemRequest request) {


### PR DESCRIPTION
- rentalId 대신 itemId가 정상적으로 반환되도록 변경

## 📝 상세 내용
json의 키(itemId)에 맞춰, 값에도 rentalId 대신 itemId가 정상적으로 들어가도록 수정했습니다.

## #️⃣ 이슈 번호

- #55 

## 💬 리뷰 요구사항


## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

