### PR TITLE
[버그수정] 가장최근 대여내역 조회 시 반납시간도 고려하도록 변경

### DIFF
--- a/src/main/java/com/rental/haedal/config/WebConfig.java
+++ b/src/main/java/com/rental/haedal/config/WebConfig.java
@@ -1,0 +1,14 @@
+package com.rental.haedal.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/returns/**")
+                .addResourceLocations("file:/home/ubuntu/app/images/returns/");
+    }
+}

--- a/src/main/java/com/rental/haedal/domain/Rental.java
+++ b/src/main/java/com/rental/haedal/domain/Rental.java
@@ -3,6 +3,7 @@ package com.rental.haedal.domain;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class Rental {
 
     @Column
     @Setter
-    private LocalDate returnDate;
+    private LocalDateTime returnDateTime;
 
     @Column
     @Setter

--- a/src/main/java/com/rental/haedal/domain/Rental.java
+++ b/src/main/java/com/rental/haedal/domain/Rental.java
@@ -39,5 +39,6 @@ public class Rental {
     private LocalDate returnDate;
 
     @Column
+    @Setter
     private String pictureUrl;
 }

--- a/src/main/java/com/rental/haedal/dto/admin/res/AdminItemDetailResponse.java
+++ b/src/main/java/com/rental/haedal/dto/admin/res/AdminItemDetailResponse.java
@@ -3,6 +3,7 @@ package com.rental.haedal.dto.admin.res;
 import com.rental.haedal.domain.enums.ItemCategory;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -12,7 +13,7 @@ public record AdminItemDetailResponse(
         String itemName,
         ItemCategory itemCategory,
         LocalDate rentalDate,
-        LocalDate returnDate,
+        LocalDateTime returnDateTime,
         String lastPictureUrl
 ) {
 }

--- a/src/main/java/com/rental/haedal/dto/admin/res/AdminItemResponse.java
+++ b/src/main/java/com/rental/haedal/dto/admin/res/AdminItemResponse.java
@@ -4,6 +4,7 @@ import com.rental.haedal.domain.enums.ItemCategory;
 import com.rental.haedal.domain.enums.ItemStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -14,7 +15,7 @@ public record AdminItemResponse(
         ItemStatus itemStatus,
         LocalDate rentalDate,
         LocalDate dueDate,
-        LocalDate returnDate,
+        LocalDateTime returnDateTime,
         String rentalMemberName
 ) {
 }

--- a/src/main/java/com/rental/haedal/dto/rental/req/ItemReturnRequest.java
+++ b/src/main/java/com/rental/haedal/dto/rental/req/ItemReturnRequest.java
@@ -1,6 +1,7 @@
 package com.rental.haedal.dto.rental.req;
 
 public record ItemReturnRequest(
-        Long itemId
+        Long itemId,
+        String base64Image
 ) {
 }

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Base64;
@@ -82,7 +82,7 @@ public class ItemService {
                     .itemName(item.getItemName())
                     .itemCategory(item.getCategory())
                     .rentalDate(recentRental.getRentalDate())
-                    .returnDate(recentRental.getReturnDate())
+                    .returnDateTime(recentRental.getReturnDateTime())
                     .lastPictureUrl(recentRental.getPictureUrl())
                     .build();
         }
@@ -127,7 +127,7 @@ public class ItemService {
             if (latestRental != null) {
                 builder.rentalDate(latestRental.getRentalDate())
                         .dueDate(latestRental.getDueDate())
-                        .returnDate(latestRental.getReturnDate())
+                        .returnDateTime(latestRental.getReturnDateTime())
                         .rentalMemberName(latestRental.getMember().getName());
             }
             return builder.build();
@@ -181,7 +181,7 @@ public class ItemService {
         // 관리자용 강제 반납처리
         if (request.itemStatus() == ItemStatus.RENTAL_AVAILABLE) {
             Rental rental = findRentalByItemId(request.itemId());
-            rental.setReturnDate(LocalDate.now());
+            rental.setReturnDateTime(LocalDateTime.now());
         }
 
         changeItemStatus(request.itemId(), request.itemStatus());
@@ -226,7 +226,7 @@ public class ItemService {
         }
 
         // 기타 물품 반납 처리
-        rental.setReturnDate(LocalDate.now());
+        rental.setReturnDateTime(LocalDateTime.now());
         changeItemStatus(rental.getItem().getId(), ItemStatus.RENTAL_AVAILABLE);
 
         return new ItemReturnResponse(rental.getItem().getId());
@@ -238,9 +238,9 @@ public class ItemService {
             throw new IllegalArgumentException("대여내역이 없는 item id: " + itemId);
         }
 
-        // 아직 반납되지 않은 대여(Rental.returnDate가 null)를 찾음
+        // 아직 반납되지 않은 대여(Rental.returnDateTime ==  null)를 찾음
         return rentals.stream()
-                .filter(r -> r.getReturnDate() == null)
+                .filter(r -> r.getReturnDateTime() == null)
                 .max(Comparator.comparing(Rental::getRentalDate))
                 .orElseThrow(() -> new IllegalArgumentException("해당 item의 반납되지 않은 대여 내역이 없습니다."));
     }

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -17,6 +17,10 @@ import com.rental.haedal.dto.rental.req.RentalRequest;
 import com.rental.haedal.dto.rental.res.*;
 import com.rental.haedal.repository.ItemRentalRepository;
 import com.rental.haedal.repository.ItemRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Base64;
+
 
 @Service
 @RequiredArgsConstructor
@@ -199,8 +205,28 @@ public class ItemService {
             throw new IllegalArgumentException("다른 회원이 대여한 item입니다.");
         }
 
-        rental.setReturnDate(LocalDate.now());
+        // Base64 이미지 디코딩 후 저장
+        String encoded = request.base64Image();
+        if (encoded != null && !encoded.isBlank()) {
+            try {
+                byte[] decodedImg = Base64.getDecoder().decode(encoded);
+                String fileName = rental.getId().toString() + ".jpg";
+                Path saveDir  = Paths.get("/home/ubuntu/app/images/returns");
+//                Path saveDir  = Paths.get("src/main/resources/static/images/returns");  // 개발용
+                Files.createDirectories(saveDir);
+                Path filePath = saveDir.resolve(fileName);  // 디렉토리와 fileName을 합쳐 최종 파일경로 생성
+                Files.write(filePath, decodedImg);
 
+                // 웹에서 접근 가능한 URL 생성 및 저장
+                String imageUrl = "/images/returns/" + rental.getId().toString();
+                rental.setPictureUrl(imageUrl);
+            } catch (IOException e) {
+                throw new RuntimeException("반납 이미지 저장 중 오류가 발생했습니다.", e);
+            }
+        }
+
+        // 기타 물품 반납 처리
+        rental.setReturnDate(LocalDate.now());
         changeItemStatus(rental.getItem().getId(), ItemStatus.RENTAL_AVAILABLE);
 
         return new ItemReturnResponse(rental.getItem().getId());

--- a/src/main/java/com/rental/haedal/service/ItemService.java
+++ b/src/main/java/com/rental/haedal/service/ItemService.java
@@ -65,27 +65,34 @@ public class ItemService {
 
         List<Rental> rentals = itemRentalRepository.findAllByItem_Id(itemId);
 
-        if (rentals.isEmpty()) {   // 대여내역이 한번도 없는경우
+        // 대여내역이 한번도 없는경우
+        if (rentals.isEmpty()) {
             return AdminItemDetailResponse.builder()
                     .itemName(item.getItemName())
                     .itemCategory(item.getCategory())
                     .build();
         }
-        else {
-            // 가장 최근 대여내역 조회
-            Rental recentRental = rentals.stream()
-                    .max(Comparator.comparing(Rental::getRentalDate)).orElse(null);
 
-            return AdminItemDetailResponse.builder()
-                    .rentalMemberName(recentRental.getMember().getName())
-                    .rentalMemberPhoneNumber(recentRental.getMember().getPhoneNumber())
-                    .itemName(item.getItemName())
-                    .itemCategory(item.getCategory())
-                    .rentalDate(recentRental.getRentalDate())
-                    .returnDateTime(recentRental.getReturnDateTime())
-                    .lastPictureUrl(recentRental.getPictureUrl())
-                    .build();
-        }
+        // 가장 최근 대여내역 조회
+        Comparator<Rental> byRentalThenReturn = Comparator
+                .comparing(Rental::getRentalDate)
+                .thenComparing(
+                        Rental::getReturnDateTime,
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                );
+        Rental recentRental = rentals.stream()
+                .max(byRentalThenReturn)
+                .orElse(null);
+
+        return AdminItemDetailResponse.builder()
+                .rentalMemberName(recentRental.getMember().getName())
+                .rentalMemberPhoneNumber(recentRental.getMember().getPhoneNumber())
+                .itemName(item.getItemName())
+                .itemCategory(item.getCategory())
+                .rentalDate(recentRental.getRentalDate())
+                .returnDateTime(recentRental.getReturnDateTime())
+                .lastPictureUrl(recentRental.getPictureUrl())
+                .build();
     }
 
     public Page<ItemResponse> getItems(ItemCategory itemCategory, Pageable pageable) {


### PR DESCRIPTION
## 📝 상세 내용
대여물품 상세조회 api에서 가장 최근 대여기록을 조회할 때, 
한 아이템을 당일 대여-반납한 내역이 여러개일 경우 가장 먼저 대여한 아이템이 선택되는 문제가 있었습니다.
이를 해결하기 위해 Rental의 returnDate를 returnDateTime로 변경하고, 가장 최근 대여내역 조회 시 반납시간도 고려하도록 변경했습니다.

## #️⃣ 이슈 번호

- #60 

## 💬 리뷰 요구사항
첫 두개의 커밋은 #59의 기능을 포함해 테스트해보려다 해당 브랜치와 머지해 생겼습니다. 
뒤 두개의 커밋만 확인해주시면 될 것 같습니다. 

## ⏰ 현재 버그


## 📷 스크린샷(선택)


## 🔗 참고 자료(선택)

